### PR TITLE
Get training working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv
 .jess
 __pycache__/
+*.ckpt

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ First, navigate to the `/latent-diffusion-models` directory.
 
 To generate images using a specified diffusion model and prompt, run `stable_txt2img.py`:
 ```
-PYTHONPATH=$(pwd) python3 ./scripts/stable_txt2img.py
-    --ddim_eta 0.0
-    --n_samples 1
-    --n_iter 1
-    --scale 10.0
-    --ddim_steps 50
-    --ckpt ./models/ldm/stable-diffusion-v1/sd-v1-4-full-ema.ckpt
+PYTHONPATH=$(pwd) python3 ./scripts/stable_txt2img.py \
+    --ddim_eta 0.0 \
+    --n_samples 4 \
+    --n_iter 1 \
+    --scale 10.0 \
+    --ddim_steps 50 \
+    --ckpt ./models/ldm/stable-diffusion-v1/sd-v1-4-full-ema.ckpt \
     --prompt "a photo of a dog" 
 ```
 where `--ckpt` specifies the model and `--prompt` specifies the text prompt.
@@ -72,14 +72,14 @@ To train,
 3. Give the model a `JOB_NAME`. Checkpoints will be saved under `./logs/${JOB_NAME}/checkpoints`, one at 500 steps and one when training finishes at 800 steps.
 4. Train by running
 ```
-PYTHONPATH=$(pwd) python3 main.py
-                --base configs/stable-diffusion/v1-finetune_unfrozen.yaml 
-                -t 
-                --actual_resume ./models/ldm/stable-diffusion-v1/sd-v1-4-full-ema.ckpt  
-                -n JOB_NAME
-                --gpus 0, 
-                --data_root /root/to/training/images 
-                --reg_data_root /root/to/regularization/images 
+PYTHONPATH=$(pwd) python3 main.py \
+                --base configs/stable-diffusion/v1-finetune-unfrozen.yaml \
+                -t \
+                --actual_resume ./models/ldm/stable-diffusion-v1/sd-v1-4-full-ema.ckpt \
+                -n JOB_NAME \
+                --gpus 0, \
+                --data_root /root/to/training/images \
+                --reg_data_root /root/to/regularization/images \
                 --class_word CLASS_NAME
 ```
 

--- a/latent-diffusion-models/ldm/data/personalized.py
+++ b/latent-diffusion-models/ldm/data/personalized.py
@@ -172,8 +172,7 @@ class PersonalizedBase(Dataset):
             self._length = self.num_images * repeats
 
         self.size = size
-        self.interpolation = {"linear": PIL.Image.LINEAR,
-                              "bilinear": PIL.Image.BILINEAR,
+        self.interpolation = {"bilinear": PIL.Image.BILINEAR,
                               "bicubic": PIL.Image.BICUBIC,
                               "lanczos": PIL.Image.LANCZOS,
                               }[interpolation]

--- a/latent-diffusion-models/ldm/models/diffusion/ddpm.py
+++ b/latent-diffusion-models/ldm/models/diffusion/ddpm.py
@@ -1091,7 +1091,7 @@ class LatentDiffusion(DDPM):
         loss_simple = self.get_loss(model_output, target, mean=False).mean([1, 2, 3])
         loss_dict.update({f'{prefix}/loss_simple': loss_simple.mean()})
 
-        logvar_t = self.logvar[t].to(self.device)
+        logvar_t = self.logvar.to(t.device)[t].to(self.device)
         loss = loss_simple / torch.exp(logvar_t) + logvar_t
         # loss = loss_simple / torch.exp(self.logvar) + self.logvar
         if self.learn_logvar:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ opencv-python
 pudb
 imageio
 imageio-ffmpeg
-pytorch-lightning
+pytorch-lightning==1.6.3
 omegaconf
 test-tube
 streamlit


### PR DESCRIPTION
Should be able to train personalized diffusion models now 🎉 

**Changes**
* Downgraded `pytorch-lightning` version from `2.4.0` to `1.6.3`.
* In `personalized.py`: removed LINEAR interpolation (since we use a newer version of pillow that deprecates LINEAR. the other way to fix is to downgrade pillow version to 9.1.0)
* In `ddpm.py`: modified such that index and tensor are on same device

**Test plan**
1. Generate four images with the prompt “a photo of a labrador dog” and move to some /path/to/labrador_dogs directory
2. Generate four images with the prompt “a photo of a dog” and move to some /path/to/dogs directory
3. Train by running the command
```
PYTHONPATH=$(pwd) python3 main.py \
                --base configs/stable-diffusion/v1-finetune-unfrozen.yaml \
                -t \
                --actual_resume ./models/ldm/stable-diffusion-v1/sd-v1-4-full-ema.ckpt \
                -n BOOOOGATEST \
                --gpus 0, \
                --data_root /path/to/labrador_dogs \
                --reg_data_root /path/to/dogs \
                --class_word dog
```
You should see checkpoints saved in `./logs/${JOB_NAME}/checkpoints` after 500 and 800 epochs respectively.